### PR TITLE
Issue with cached module under test

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -84,6 +84,7 @@ function hookedLoader(request, parent, isMain) {
             allow = registeredAllowables[request];
             if (allow.unhook) {
                 file = resolveFilename(request, parent);
+                delete m._cache[file];
                 if (file.indexOf('/') !== -1 && allow.paths.indexOf(file) === -1) {
                     allow.paths.push(file);
                 }


### PR DESCRIPTION
When you require a module that is registerAllowable + unhook it can be cached beforehand, so all other stubs won't load properly, especially if this is the 'file-under-test'. So I remove this module from the cache just before calling the native require.
