### PR TITLE
Implemented resolving of relative module names to absolute paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   "engines": {
     "node": ">=0.4.5"
   },
-  "dependencies": {},
+  "dependencies": {
+    "require-like": "0.1.x"
+  },
   "devDependencies": {
     "nodeunit" : "0.6.x",
     "sinon" : "1.2.x"


### PR DESCRIPTION
Specifying files to mock by a relative name is not enough if you require the same file multiple times from different directories. So I added an option to mockery to convert all relative filenames to absolute ones, based on the test file for example. There are two advantages of doing so:
1. You can specify the filenames to mock, relative to the test file -- i.e the same way requires work, so its a no-brainer
2. Requiring the same file from multiple locations would return the given mock, because all filenames are converted to absolute ones when requiring
