### PR TITLE
Resolve path to module

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ You register your mocks with Mockery to tell it which mocks to provide for which
 The arguments to `registerMock` are as follows:
 
 * _module_, the name or path of the module for which a mock is being
-registered. This must exactly match the argument to `require`; there is no
-"clever" matching.
+registered. Path to the _module_ is resolved the same way as when `require` is used.
 * _mock_, the mock to be provided. Whatever is provided here is what will
 become the result of subsequent `require` calls; that is, the `exports` of the
 module.
@@ -115,8 +114,7 @@ module instead.
 The arguments to `registerSubstitute` are as follows:
 
 * _module_, the name or path of the module for which a substitute is being
-registered. This must exactly match the argument to `require`; there is no
-"clever" matching.
+registered. Path to the _module_ is resolved the same way as when `require` is used.
 * _substitute_, the name or path of the module to substitute for _module_.
 
 If you no longer want your substitute to be used, you can deregister it:

--- a/test/mockery.functional.js
+++ b/test/mockery.functional.js
@@ -484,7 +484,7 @@ module.exports = testCase({
 
         "and mockery is enabled without the clean cache option": testCase({
             setUp: function (callback) {
-                mockery.registerMock('./fake_module', mock_fake_module);
+                mockery.registerMock('./fixtures/fake_module', mock_fake_module);
                 mockery.registerAllowable('./fixtures/intermediary');
                 mockery.enable({ useCleanCache: false });
                 callback();
@@ -499,7 +499,7 @@ module.exports = testCase({
 
         "and mockery is enabled with the clean cache option": testCase({
             setUp: function (callback) {
-                mockery.registerMock('./fake_module', mock_fake_module);
+                mockery.registerMock('./fixtures/fake_module', mock_fake_module);
                 mockery.registerAllowable('./fixtures/intermediary');
                 mockery.enable({ useCleanCache: true });
                 callback();


### PR DESCRIPTION
I changed the way how mocked modules are located. Now it works just like `require`, i.e. you `registerMock` with path relative to the current directory. This way you only need to register the mock once, no matter how many times with what different relative path it is required.

I found this useful when writing tests for my application.
