### PR TITLE
Fixed an apparent loss of the original loader

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -38,7 +38,6 @@ var m = require('module'),
     registeredMocks = {},
     registeredSubstitutes = {},
     registeredAllowables = {},
-    originalLoader = null,
     originalCache = null,
     defaultOptions = {
         useCleanCache: false,
@@ -75,7 +74,7 @@ function getEffectiveOptions(opts) {
 function hookedLoader(request, parent, isMain) {
     var subst, allow, file;
 
-    if (!originalLoader) {
+    if (!m.__load) {
         throw new Error("Loader has not been hooked");
     }
 
@@ -86,7 +85,7 @@ function hookedLoader(request, parent, isMain) {
     if (registeredSubstitutes.hasOwnProperty(request)) {
         subst = registeredSubstitutes[request];
         if (!subst.module && subst.name) {
-            subst.module = originalLoader(subst.name, parent, isMain);
+            subst.module = m.__load(subst.name, parent, isMain);
         }
         if (!subst.module) {
             throw new Error("Misconfigured substitute for '" + request + "'");
@@ -108,7 +107,7 @@ function hookedLoader(request, parent, isMain) {
         }
     }
 
-    return originalLoader(request, parent, isMain);
+    return m.__load(request, parent, isMain);
 }
 
 /*
@@ -117,7 +116,7 @@ function hookedLoader(request, parent, isMain) {
  * function more than once will have no ill effects.
  */
 function enable(opts) {
-    if (originalLoader) {
+    if (m.__load) {
         // Already hooked
         return;
     }
@@ -129,7 +128,7 @@ function enable(opts) {
         m._cache = {};
     }
 
-    originalLoader = m._load;
+    m.__load = m._load;
     m._load = hookedLoader;
 }
 
@@ -139,7 +138,7 @@ function enable(opts) {
  * will have no ill effects.
  */
 function disable() {
-    if (!originalLoader) {
+    if (!m.__load) {
         // Not hooked
         return;
     }
@@ -149,8 +148,8 @@ function disable() {
         originalCache = null;
     }
 
-    m._load = originalLoader;
-    originalLoader = null;
+    m._load = m.__load;
+    m.__load = null;
 }
 
  /*

--- a/test/1-general.js
+++ b/test/1-general.js
@@ -6,6 +6,7 @@ module and test the dead code cases.
 var vows = require('vows'),
     assert = require('assert'),
     m = require('module'),
+    originalLoader, 
     mockery = require('../mockery');
 
 var tests = {
@@ -19,7 +20,7 @@ var tests = {
         },
         'and without a module loader': {
             topic: function() {
-                m.__load = m._load;
+                originalLoader = m._load;
                 m._load = null;
                 return m;
             },
@@ -31,8 +32,7 @@ var tests = {
                 }, /Loader has not been hooked/);
             },
             teardown: function() {
-                m._load = m.__load;
-                delete m.__load;
+                m._load = originalLoader;
             }
         }
     }


### PR DESCRIPTION
I was [getting an error](https://github.com/mfncooper/mockery/issues/32) with the `originalLoader` being lost somehow during my tests. I suspect it was because I was probably doing a combination of resetting caches and re-requiring in mockery in a cavalier fashion. 

Either way, by taking the reference out of the mockery closure and putting it on the module, it no longer suffers from this problem. 