### PR TITLE
Register allowed modules via regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ and similarly to deregister several modules at once, as you would expect:
 
     mockery.deregisterAllowables(['async', 'path', 'util']);
 
+Sometimes it's useful to allow bunch of modules to be allowed without a warnings.
+For example, when your code transpiled via babel. In that case you can allow them
+
+    mockery.registerAllowableRegExp(/.+\$\.object-assign/ig);
+
+and similarly to deregister module, as you would expect:
+
+    mockery.deregisterAllowableRegExp(/.+\$\.object-assign/ig);
+
 ### Unhooking
 
 By default, the Node module loader will load a given module only once, caching

--- a/mockery.js
+++ b/mockery.js
@@ -38,6 +38,7 @@ var m = require('module'),
     registeredMocks = {},
     registeredSubstitutes = {},
     registeredAllowables = {},
+    registeredAllowableRegExps = {},
     originalLoader = null,
     originalCache = null,
     defaultOptions = {
@@ -94,8 +95,10 @@ function hookedLoader(request, parent, isMain) {
         return subst.module;
     }
 
-    if (registeredAllowables.hasOwnProperty(request)) {
-        allow = registeredAllowables[request];
+    if ((registeredAllowables.hasOwnProperty(request) && (
+        allow = registeredAllowables[request])
+      ) || (allow = isRequesRegisteredAsRegexp(request))
+    ) {
         if (allow.unhook) {
             file = m._resolveFilename(request, parent);
             if (file.indexOf('/') !== -1 && allow.paths.indexOf(file) === -1) {
@@ -257,6 +260,42 @@ function registerAllowables(mods, unhook) {
     });
 }
 
+/**
+ * Register a module as 'allowed' using regular expression as a module name,
+ * even if a mock or substitute for it has not been registered, mockery will
+ * not complain when it is loaded via 'require'.
+ */
+function registerAllowableRegExp(regExp, unhook) {
+    registeredAllowableRegExps[String(regExp)] = {
+        unhook: !!unhook,
+        paths: [],
+        regExp: regExp
+    };
+}
+
+/**
+ * check if request is 'allowed'
+ * @param request {String}
+ */
+function isRequesRegisteredAsRegexp(request) {
+
+    var
+      regExps = Object.keys(registeredAllowableRegExps),
+      regExpsLen = regExps.length,
+      allow;
+
+    if (!regExpsLen) {
+        return false;
+    }
+    while(regExpsLen--) {
+        allow = registeredAllowableRegExps[regExps[regExpsLen]];
+        if (request.match(allow.regExp)) {
+            return allow;
+        }
+    }
+    return false;
+}
+
 /*
  * Deregister a module as 'allowed'. A subsequent 'require' for that module
  * will generate a warning that the module is not allowed, unless or until a
@@ -286,13 +325,32 @@ function deregisterAllowables(mods) {
 }
 
 /*
+ * Deregister a module as 'allowed' which has been registered as regexp.
+ * A subsequent 'require' for that module will generate a warning that
+ * the module is not allowed, unless or until a mock or substitute is
+ * registered for that module.
+ */
+function deregisterAllowableRegExp(regExp) {
+    if (registeredAllowableRegExps.hasOwnProperty(String(regExp))) {
+        var allow = registeredAllowableRegExps[regExp];
+        if (allow.unhook) {
+            allow.paths.forEach(function (p) {
+                delete m._cache[p];
+            });
+        }
+        delete registeredAllowableRegExps[regExp];
+    }
+}
+
+/*
  * Deregister all mocks, substitutes, and allowed modules, resetting the state
  * to a clean slate. This does not affect the enabled / disabled state of
  * mockery, though.
  */
 function deregisterAll() {
-    Object.keys(registeredAllowables).forEach(function (mod) {
-        var allow = registeredAllowables[mod];
+    Object.keys(registeredAllowables).concat(Object.keys(registeredAllowableRegExps))
+      .forEach(function (mod) {
+        var allow = registeredAllowables[mod] || registeredAllowableRegExps[mod];
         if (allow.unhook) {
             allow.paths.forEach(function (p) {
                 delete m._cache[p];
@@ -303,6 +361,7 @@ function deregisterAll() {
     registeredMocks = {};
     registeredSubstitutes = {};
     registeredAllowables = {};
+    registeredAllowableRegExps = {};
 }
 
 // Exported functions
@@ -315,8 +374,10 @@ exports.registerMock = registerMock;
 exports.registerSubstitute = registerSubstitute;
 exports.registerAllowable = registerAllowable;
 exports.registerAllowables = registerAllowables;
+exports.registerAllowableRegExp = registerAllowableRegExp;
 exports.deregisterMock = deregisterMock;
 exports.deregisterSubstitute = deregisterSubstitute;
 exports.deregisterAllowable = deregisterAllowable;
 exports.deregisterAllowables = deregisterAllowables;
+exports.deregisterAllowableRegExp = deregisterAllowableRegExp;
 exports.deregisterAll = deregisterAll;

--- a/test/fixtures/$.object-assign.js
+++ b/test/fixtures/$.object-assign.js
@@ -1,0 +1,3 @@
+exports.foo = function () {
+    return 'object assign';
+};

--- a/test/logging-allowable.js
+++ b/test/logging-allowable.js
@@ -27,6 +27,19 @@ var tests = {
                 mock_console.verify();
                 mock_console.restore();
             },
+            "requiring the module which is allowed via regexp causes no warning to be logged": function () {
+                var mock_console, fake_module;
+
+                mock_console = sinon.mock(console);
+                mock_console.expects('warn').never();
+
+                mockery.registerAllowableRegExp(/.+\$\.object-assign/ig);
+                fake_module = require('./fixtures/$.object-assign');
+                assert.equal(fake_module.foo(), 'object assign');
+
+                mock_console.verify();
+                mock_console.restore();
+            },
             "and the allowable is deregistered": {
                 topic: function () {
                     mockery.deregisterAllowable('./fixtures/fake_module');
@@ -40,6 +53,20 @@ var tests = {
 
                     fake_module = require('./fixtures/fake_module');
                     assert.equal(fake_module.foo(), 'real foo');
+
+                    mock_console.verify();
+                    mock_console.restore();
+                },
+                "requiring the module which is allowed via regexp causes a warning to be logged": function () {
+                    var mock_console, fake_module;
+
+                    mockery.deregisterAllowableRegExp(/.+\$\.object-assign/ig);
+
+                    mock_console = sinon.mock(console);
+                    mock_console.expects('warn').once();
+
+                    fake_module = require('./fixtures/$.object-assign');
+                    assert.equal(fake_module.foo(), 'object assign');
 
                     mock_console.verify();
                     mock_console.restore();

--- a/test/registered.js
+++ b/test/registered.js
@@ -27,6 +27,11 @@ var tests = {
             mockery.registerAllowable('./fixtures/fake_module');
             var fake_module = require('./fixtures/fake_module');
             assert.equal(fake_module.foo(), 'real foo');
+
+            mockery.registerAllowableRegExp(/.+\$\.object-assign/ig);
+            //require without a warning
+            var objectAssign = require('./fixtures/$.object-assign');
+            assert.equal(objectAssign.foo(), 'object assign');
         },
         "and mockery is then disabled requiring the module returns the original module": function () {
             mockery.disable();


### PR DESCRIPTION
I faced an issue with dozens of warnings as in this issue https://github.com/mfncooper/mockery/issues/35. 
The solution I propose is just allow to register modules via regexp. Which I find more or less acceptable. 
This way I am able to allow all babel and core-js modules with couple of lines.