### PR TITLE
Fix unhook flag for allowables not working on Windows

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -98,7 +98,7 @@ function hookedLoader(request, parent, isMain) {
         allow = registeredAllowables[request];
         if (allow.unhook) {
             file = m._resolveFilename(request, parent);
-            if (file.indexOf('/') !== -1 && allow.paths.indexOf(file) === -1) {
+            if ((file.indexOf('/') !== -1 || file.indexOf('\\') !== -1) && allow.paths.indexOf(file) === -1) {
                 allow.paths.push(file);
             }
         }


### PR DESCRIPTION
The code currently only checks for forward slash (/) and not backslash (\).  Fix to check for either.