### PR TITLE
Add node 0.12 and 4 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - "0.10"
   - "0.11"
+  - "0.12"
+  - "4"


### PR DESCRIPTION
This is a test to ensure mockery works with the latest Nodejs.