### PR TITLE
Repopulating the cache with native modules that have not been mocked.

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -108,6 +108,17 @@ function hookedLoader(request, parent, isMain) {
         }
     }
 
+    // Starting in node 0.12 node won't reload native modules
+    // The reason is that native modules can register themselves to be loaded automatically
+    // This will re-populate the cache with the native modules that have not been mocked
+    if(originalCache) {
+        Object.keys(originalCache).forEach(function(k) {
+            if (k.indexOf('\.node') > -1 && !m._cache[k]) {
+                m._cache[k] = originalCache[k];
+            }
+        });
+    }
+
     return originalLoader(request, parent, isMain);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockery",
-  "version": "1.4.1",
+  "version": "1.5.1",
   "description": "Simplifying the use of mocks with Node.js",
   "keywords": [
     "mock",


### PR DESCRIPTION
This is required due to changes in node 0.12 and above where native modules are not reloaded. This should fix issue #45.