### PR TITLE
Increase performance for resetting cache with native modules

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -108,17 +108,6 @@ function hookedLoader(request, parent, isMain) {
         }
     }
 
-    // Starting in node 0.12 node won't reload native modules
-    // The reason is that native modules can register themselves to be loaded automatically
-    // This will re-populate the cache with the native modules that have not been mocked
-    if(originalCache) {
-        Object.keys(originalCache).forEach(function(k) {
-            if (k.indexOf('\.node') > -1 && !m._cache[k]) {
-                m._cache[k] = originalCache[k];
-            }
-        });
-    }
-
     return originalLoader(request, parent, isMain);
 }
 
@@ -138,6 +127,7 @@ function enable(opts) {
     if (options.useCleanCache) {
         originalCache = m._cache;
         m._cache = {};
+        repopulateNative();
     }
 
     originalLoader = m._load;
@@ -172,7 +162,21 @@ function disable() {
 function resetCache() {
     if (options.useCleanCache && originalCache) {
         m._cache = {};
+        repopulateNative();
     }
+}
+
+/*
+ * Starting in node 0.12 node won't reload native modules
+ * The reason is that native modules can register themselves to be loaded automatically
+ * This will re-populate the cache with the native modules that have not been mocked
+ */
+function repopulateNative() {
+  Object.keys(originalCache).forEach(function(k) {
+      if (k.indexOf('\.node') > -1 && !m._cache[k]) {
+          m._cache[k] = originalCache[k];
+      }
+  });
 }
 
 /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mockery",
-  "version": "1.5.1",
+  "version": "1.6.1",
   "description": "Simplifying the use of mocks with Node.js",
   "keywords": [
     "mock",


### PR DESCRIPTION
mfncooper/mockery#46 caused some large performance issues as it is unnecessarily checking the cache every time a module is loaded.  The check itself does not take long, but the sheer number of times it's called (uselessly) when mocking even a single module can be problematic.  When mocking a module that itself has many other imports, this check can be called 100+ times, when it only needed to be called once.

I've moved it so that the cache is only repopulated with native modules when it's reset.  This should hopefully allow keeping the fix to mfncooper/mockery#45 while keeping the performance impact to a minimum.