### PR TITLE
deal with self-register bug in post-enable require

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: node_js
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+env: CXX=g++-4.9 CC=gcc-4.9
 node_js:
   - "0.10"
   - "0.11"
   - "0.12"
   - "4"
+  - "6"

--- a/mockery.js
+++ b/mockery.js
@@ -146,6 +146,16 @@ function disable() {
     }
 
     if (options.useCleanCache) {
+        // Previously this just set m._cache to originalCache. This would make
+        // node re-require native addons that were required while mockery was
+        // enabled, which breaks it in node@>=0.12. Instead populate
+        // originalCache with any native addons that were first required since
+        // mockery was enabled.
+        Object.keys(m._cache).forEach(function(k){
+            if (k.indexOf('\.node') > -1 && !originalCache[k]) {
+                originalCache[k] = m._cache[k];
+            }
+        });
         m._cache = originalCache;
         originalCache = null;
     }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "istanbul": "~0.3.5",
     "jshint": "~2.6.0",
     "sinon": "1.2.x",
+    "unix-dgram": "^0.2.3",
     "vows": "~0.8.1"
   },
   "scripts": {

--- a/test/self-register.js
+++ b/test/self-register.js
@@ -1,0 +1,36 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    mockery = require('../mockery');
+ 
+var registerBin = function () {
+    var error = 0;
+    mockery.enable({
+        warnOnUnregistered: false,
+        useCleanCache: true
+    });
+    try {
+        require('unix-dgram'); //or some other binary module
+    } catch (err) {
+        error = 1;
+    }
+    mockery.deregisterAll();
+    mockery.disable();
+    return error;
+};
+
+var tests = {
+    "register bin": {
+        topic: function () {
+            var errors = 0;
+            for (var i = 0; i < 10; i++) {
+                errors += registerBin();
+            }
+            return errors;
+        },
+        "should be able to register a bin module multiple times": function(topic) {
+            assert.equal(topic, 0);
+        }
+    }
+};
+
+vows.describe('module-failed-to-self-register').addBatch(tests).export(module);


### PR DESCRIPTION
In cases where native addons were first required after mockery was
enabled, and then this happened again later, you'd get a 'did not
self-register' error. This has been corrected by populating the
originalCache with native addons that have been required since mockery
was enabled.

Test case courtesy of @petey.