### PR TITLE
Fixes mfncooper/mockery #51

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -156,6 +156,7 @@ function disable() {
                 originalCache[k] = m._cache[k];
             }
         });
+        removeParentReferences();
         m._cache = originalCache;
         originalCache = null;
     }
@@ -171,6 +172,7 @@ function disable() {
  */
 function resetCache() {
     if (options.useCleanCache && originalCache) {
+        removeParentReferences();
         m._cache = {};
         repopulateNative();
     }
@@ -328,6 +330,23 @@ function deregisterAll() {
     registeredMocks = {};
     registeredSubstitutes = {};
     registeredAllowables = {};
+}
+
+/**
+ * Remove references to modules in the mockery cache from
+ * their parents' children.
+ */
+function removeParentReferences() {
+    Object.keys(m._cache).forEach(function(k){
+        if (k.indexOf('\.node') === -1) {
+            // don't touch native modules, because they're special
+            var mod = m._cache[k];
+            var idx = mod.parent.children.indexOf(mod);
+            if (idx > -1) {
+                mod.parent.children.splice(idx, 1);
+            }
+        }
+    });
 }
 
 // Exported functions


### PR DESCRIPTION
This fixes #51.

For each mock in the hookedLoader cache, on disable
or reset, remove it from its parent's children list.

This gets rid of the leak in our test suite, which is relatively larges (1100 specs, each one attempting to use a clean mockery cache). I'm by no means an expert on the node module API though, so it's possible that I did something dumb here.
