### PR TITLE
fix: add null checks before removing parent refs

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -341,7 +341,7 @@ function removeParentReferences() {
         if (k.indexOf('\.node') === -1) {
             // don't touch native modules, because they're special
             var mod = m._cache[k];
-            var idx = mod.parent.children.indexOf(mod);
+            var idx = mod.parent && mod.parent.children && mod.parent.children.indexOf(mod);
             if (idx > -1) {
                 mod.parent.children.splice(idx, 1);
             }


### PR DESCRIPTION
One of our projects has a dependency to newrelic module, currently to version 1.40.0. The newrelic module code, attaches a property to the require.cache object, see https://github.com/newrelic/node-newrelic/blob/master/index.js#L114.

When calling the disable method on mockery, version 2.0.0, it will break, because the code on https://github.com/mfncooper/mockery/pull/57 assumes that anything on the require.cache object will be a module with a parent property. This is not the case with this newrelic module, and potentially with another ones attaching stuff to the rquire.cache.