### PR TITLE
CVE-2022-37614 - resolve prototype pollution vuln

### DIFF
--- a/mockery.js
+++ b/mockery.js
@@ -52,22 +52,22 @@ var m = require('module'),
  * the effective options, and return those.
  */
 function getEffectiveOptions(opts) {
-  var defaultOptionsTemp = {};
+  var effectiveOptions = {};
 
   for (var key in defaultOptions) {
     if (defaultOptions.hasOwnProperty(key)) {
-      defaultOptionsTemp[key] = defaultOptions[key];
+      effectiveOptions[key] = defaultOptions[key];
     }
   }
 
   if (opts) {
-    for (var defaultKey in defaultOptionsTemp) {
-      if (defaultOptionsTemp.hasOwnProperty(defaultKey) && opts[defaultKey]) {
-        defaultOptionsTemp[defaultKey] = opts[defaultKey];
+    for (var defaultKey in effectiveOptions) {
+      if (effectiveOptions.hasOwnProperty(defaultKey) && opts[defaultKey]) {
+        effectiveOptions[defaultKey] = opts[defaultKey];
       }
     }
   }
-  return defaultOptionsTemp;
+  return effectiveOptions;
 }
 
 /*

--- a/mockery.js
+++ b/mockery.js
@@ -52,17 +52,22 @@ var m = require('module'),
  * the effective options, and return those.
  */
 function getEffectiveOptions(opts) {
-    var options = {};
+  var defaultOptionsTemp = {};
 
-    Object.keys(defaultOptions).forEach(function (key) {
-        options[key] = defaultOptions[key];
-    });
-    if (opts) {
-        Object.keys(opts).forEach(function (key) {
-            options[key] = opts[key];
-        });
+  for (var key in defaultOptions) {
+    if (defaultOptions.hasOwnProperty(key)) {
+      defaultOptionsTemp[key] = defaultOptions[key];
     }
-    return options;
+  }
+
+  if (opts) {
+    for (var defaultKey in defaultOptionsTemp) {
+      if (defaultOptionsTemp.hasOwnProperty(defaultKey) && opts[defaultKey]) {
+        defaultOptionsTemp[defaultKey] = opts[defaultKey];
+      }
+    }
+  }
+  return defaultOptionsTemp;
 }
 
 /*

--- a/mockery.js
+++ b/mockery.js
@@ -61,9 +61,9 @@ function getEffectiveOptions(opts) {
   }
 
   if (opts) {
-    for (var defaultKey in effectiveOptions) {
-      if (effectiveOptions.hasOwnProperty(defaultKey) && opts[defaultKey]) {
-        effectiveOptions[defaultKey] = opts[defaultKey];
+    for (var key in effectiveOptions) {
+        if (effectiveOptions.hasOwnProperty(key) && opts.hasOwnProperty(key)) {
+            effectiveOptions[key] = opts[key];
       }
     }
   }


### PR DESCRIPTION
### [CVE-2022-37614/Prototype pollution found in mockery.js](https://github.com/mfncooper/mockery/issues/77)
Resolve prototype pollution vulnerability by only mapping fields that exist in the defaultOptions object from the user provided opts object.

Default:

>     defaultOptions = {
>         useCleanCache: false,
>         warnOnReplace: true,
>         warnOnUnregistered: true
>     }

User provided:
>     opts = {
>         other1: 2,
>         other2: 5,
>         warnOnUnregistered: false
>     }

Result:
>     effectiveOptions = {
>         useCleanCache: false,
>         warnOnReplace: true,
>         warnOnUnregistered: false  // <-- updated
>     }